### PR TITLE
fix(tcp): prevent an infinite loop caused by a self-connected tcp socket

### DIFF
--- a/arch/posix/ua_architecture.h
+++ b/arch/posix/ua_architecture.h
@@ -53,6 +53,8 @@
 #define UA_connect connect
 #define UA_getsockopt getsockopt
 #define UA_setsockopt setsockopt
+#define UA_getsockname getsockname
+#define UA_getpeername getpeername
 #define UA_inet_pton inet_pton
 #define UA_bind bind
 #if UA_IPV6

--- a/arch/win32/ua_architecture.h
+++ b/arch/win32/ua_architecture.h
@@ -57,6 +57,10 @@ typedef SSIZE_T ssize_t;
     getsockopt(sockfd, level, optname, (char*) (optval), optlen)
 #define UA_setsockopt(sockfd, level, optname, optval, optlen) \
     setsockopt(sockfd, level, optname, (const char*) (optval), optlen)
+#define UA_getsockname(sockfd, addr, addrlen) \
+    getsockname(sockfd, addr, addrlen)
+#define UA_getpeername(sockfd, addr, addrlen) \
+    getpeername(sockfd, addr, addrlen)
 #define UA_inet_pton InetPton
 #define UA_bind bind
 

--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -543,6 +543,7 @@ processServiceResponse(void *application, UA_SecureChannel *channel,
     default:
         UA_LOG_TRACE_CHANNEL(client->config.logging, channel,
                              "Invalid message type");
+        UA_SecureChannel_shutdown(channel, UA_SHUTDOWNREASON_SECURITYREJECT);
         channel->state = UA_SECURECHANNELSTATE_CLOSING;
         return UA_STATUSCODE_BADTCPMESSAGETYPEINVALID;
     }


### PR DESCRIPTION
Sometimes, if a client tries to connect to a non-existent server on localhost (on a port that no one is listening on), the client may accidentally establish a connection with itself by connecting to the same socket from which it sent the connection request. In an attempt to close such a connection, the client ended up in an endless loop from which it could no longer exit.
To bypass this error, a check for the coincidence of local and remote addresses has been added to the connection setup code, and a forced closure of the socket due to a timeout has been added to the code for closing a secure channel.